### PR TITLE
correct denominator for n_eff/N

### DIFF
--- a/inst/ShinyStan/server_files/pages/diagnose/server/rhat_neff_mcse.R
+++ b/inst/ShinyStan/server_files/pages/diagnose/server/rhat_neff_mcse.R
@@ -16,7 +16,7 @@
 # rhat, n_eff, mcse -------------------------------------------------------
 n_eff_plot <- reactive({
   dat <- fit_summary[,"n_eff"]
-  N <- nrow(samps_post_warmup)
+  N <- prod(dim(samps_post_warmup)[1:2])
   dat <- data.frame(parameter = names(dat), x = dat / N)
   do.call(".rhat_neff_mcse_hist", args = list(
     dat = dat,


### PR DESCRIPTION
Fixes denominator in n_eff / N calculation so that N is the number of post-warmup iterations for all chains combined rather than just for a single chain. 