### PR TITLE
deploy_shinystan generates shiny code for private server deployment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,4 +57,4 @@ Suggests:
     testthat
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/R/deploy_shinystan.R
+++ b/R/deploy_shinystan.R
@@ -11,10 +11,11 @@
 # this program; if not, see <http://www.gnu.org/licenses/>.
 
 
-#' Deploy a 'ShinyStan' app on the web using 'shinyapps.io' by 'RStudio'
+#' Deploy a 'ShinyStan' app on the web using 'shinyapps.io' by 'RStudio' or 
+#' render a Shiny code, which can be uploaded and run on a private server.
 #'
-#' Requires a (free or paid) 'ShinyApps' account. Visit
-#' \url{http://www.shinyapps.io/} to sign up.
+#' Uploading to the 'shinyapps.io' requires a (free or paid) 'ShinyApps' account. 
+#' Visit \url{http://www.shinyapps.io/} to sign up.
 #'
 #' @export
 #' @template args-sso
@@ -23,6 +24,10 @@
 #'   and underscores.
 #' @param account shinyapps.io account username. Only required if more than one
 #'   account is configured on the system.
+#' @param local If TRUE, the app won't be sent to shinyapps.io but the Shiny code
+#'   will be generated and saved in a folder in the working directory.
+#' @param path If \code{local} = TRUE, this argument can be used to specify the absolute
+#'   path to a location, where the Shiny code should be generated.
 #' @param ... Optional arguments. See Details.
 #' @param deploy Should the app be deployed? The only reason for this to be
 #'   \code{FALSE} is if you just want to check that the preprocessing before
@@ -43,8 +48,8 @@
 #'   \code{ppcheck_yrep} (but not \code{ppcheck_data}) can also be set
 #'   interactively on shinyapps.io when using the app.
 #'
-#' @seealso The example in the \emph{Deploying to shinyapps.io} vignette that
-#'   comes with this package.
+#' @seealso The example in the \emph{Deploying to shinyapps.io or private server} 
+#'   vignette that comes with this package.
 #'
 #'   \url{http://www.shinyapps.io/} to sign up for a free or paid 'ShinyApps'
 #'   account and for details on how to configure your account on your local
@@ -62,11 +67,15 @@
 #' # the 'account' argument.
 #'
 #' deploy_shinystan(sso, appName = "my-model")
+#' 
+#' # If you only want to generate the Shiny code set the 'local' = TRUE argument.
+#'
+#' deploy_shinystan(sso, appName = "my-model", local = TRUE)
 #' }
 #'
 #' @importFrom rsconnect deployApp
 #'
-deploy_shinystan <- function(sso, appName, account = NULL, ..., deploy = TRUE) {
+deploy_shinystan <- function(sso, appName, account = NULL, ..., deploy = TRUE,  local = FALSE, path = getwd()) {
   sso_check(sso)
   if (missing(appName))
     stop("'appName' is required.")
@@ -133,12 +142,18 @@ deploy_shinystan <- function(sso, appName, account = NULL, ..., deploy = TRUE) {
   if (!deploy)
     return(invisible(deployDir))
 
-  rsconnect::deployApp(
-    appDir = deployDir,
-    appName = appName,
-    account = account,
-    lint = TRUE
-  )
+  if (local) {
+    # check if dirrectory exists, if not, create it
+    ifelse(!dir.exists(file.path(path, appName)), dir.create(file.path(path, appName)), FALSE)                    
+    file.copy(from = file.path(deployDir,list.files(deployDir)), to = file.path(path, appName), recursive = TRUE)
+  }else{
+    rsconnect::deployApp(
+      appDir = deployDir,
+      appName = appName,
+      account = account,
+      lint = TRUE
+    )
+  }
 }
 
 

--- a/man/as.shinystan.Rd
+++ b/man/as.shinystan.Rd
@@ -15,13 +15,15 @@ as.shinystan(X, ...)
 
 is.shinystan(X)
 
-\S4method{as.shinystan}{array}(X, model_name = "unnamed model", warmup = 0,
-  burnin = 0, param_dims = list(), model_code = NULL, note = NULL,
-  sampler_params = NULL, algorithm = NULL, max_treedepth = NULL, ...)
+\S4method{as.shinystan}{array}(X, model_name = "unnamed model",
+  warmup = 0, burnin = 0, param_dims = list(), model_code = NULL,
+  note = NULL, sampler_params = NULL, algorithm = NULL,
+  max_treedepth = NULL, ...)
 
-\S4method{as.shinystan}{list}(X, model_name = "unnamed model", warmup = 0,
-  burnin = 0, param_dims = list(), model_code = NULL, note = NULL,
-  sampler_params = NULL, algorithm = NULL, max_treedepth = NULL, ...)
+\S4method{as.shinystan}{list}(X, model_name = "unnamed model",
+  warmup = 0, burnin = 0, param_dims = list(), model_code = NULL,
+  note = NULL, sampler_params = NULL, algorithm = NULL,
+  max_treedepth = NULL, ...)
 
 \S4method{as.shinystan}{mcmc.list}(X, model_name = "unnamed model",
   warmup = 0, burnin = 0, param_dims = list(), model_code = NULL,

--- a/man/deploy_shinystan.Rd
+++ b/man/deploy_shinystan.Rd
@@ -2,9 +2,11 @@
 % Please edit documentation in R/deploy_shinystan.R
 \name{deploy_shinystan}
 \alias{deploy_shinystan}
-\title{Deploy a 'ShinyStan' app on the web using 'shinyapps.io' by 'RStudio'}
+\title{Deploy a 'ShinyStan' app on the web using 'shinyapps.io' by 'RStudio' or 
+render a Shiny code, which can be uploaded and run on a private server.}
 \usage{
-deploy_shinystan(sso, appName, account = NULL, ..., deploy = TRUE)
+deploy_shinystan(sso, appName, account = NULL, ..., deploy = TRUE,
+  local = FALSE, path = getwd())
 }
 \arguments{
 \item{sso}{A \code{\link[=as.shinystan]{shinystan object}}.}
@@ -21,6 +23,12 @@ account is configured on the system.}
 \item{deploy}{Should the app be deployed? The only reason for this to be
 \code{FALSE} is if you just want to check that the preprocessing before
 deployment is successful.}
+
+\item{local}{If TRUE, the app won't be sent to shinyapps.io but the Shiny code
+will be generated and saved in a folder in the working directory.}
+
+\item{path}{If \code{local} = TRUE, this argument can be used to specify the absolute
+path to a location, where the Shiny code should be generated.}
 }
 \value{
 \link[=invisible]{Invisibly}, \code{TRUE} if deployment succeeded
@@ -29,8 +37,8 @@ deployment is successful.}
   for deployment (also invisibly).
 }
 \description{
-Requires a (free or paid) 'ShinyApps' account. Visit
-\url{http://www.shinyapps.io/} to sign up.
+Uploading to the 'shinyapps.io' requires a (free or paid) 'ShinyApps' account. 
+Visit \url{http://www.shinyapps.io/} to sign up.
 }
 \details{
 In \code{...}, the arguments \code{ppcheck_data} and
@@ -55,12 +63,16 @@ deploy_shinystan(sso, appName = "my-model", account = "username")
 # the 'account' argument.
 
 deploy_shinystan(sso, appName = "my-model")
+
+# If you only want to generate the Shiny code set the 'local' = TRUE argument.
+
+deploy_shinystan(sso, appName = "my-model", local = TRUE)
 }
 
 }
 \seealso{
-The example in the \emph{Deploying to shinyapps.io} vignette that
-  comes with this package.
+The example in the \emph{Deploying to shinyapps.io or private server} 
+  vignette that comes with this package.
 
   \url{http://www.shinyapps.io/} to sign up for a free or paid 'ShinyApps'
   account and for details on how to configure your account on your local

--- a/vignettes/deploy_shinystan.Rmd
+++ b/vignettes/deploy_shinystan.Rmd
@@ -1,18 +1,20 @@
 ---
-title: 'Deploying to shinyapps.io'
+title: 'Deploying to shinyapps.io or private server'
 date: "09/17/2015"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{ShinyStan: Deploying to shinyapps.io}
+  %\VignetteIndexEntry{ShinyStan: Deploying to shinyapps.io or private server}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 
-Create a ShinyStan app unique to your model and host it online with RStudio's ShinyApps service (shinyapps.io). Each app you deploy will have a unique url.  
+Create a ShinyStan app unique to your model and host it online with RStudio's ShinyApps service (shinyapps.io). Each app you deploy will have a unique url. Or generate the Shiny code and host the app on your own server.
 
 *Note: R users who don't use RStudio's IDE can still deploy ShinyStan apps to shinyapps.io.* 
 
-## Step 1: ShinyApps account
+## Deploying to shinyapps.io
+
+### Step 1: ShinyApps account
 
 **Signup**
 
@@ -37,7 +39,7 @@ rsconnect::setAccountInfo(name, token, secret)
 where `name` is your ShinyApps account name, and `token` and `secret` can be
 found from your ShinyApps account web page.
 
-## Step 2: Use `deploy_shinystan` to deploy your app to shinyapps.io
+### Step 2: Use `deploy_shinystan` to deploy your app to shinyapps.io
 
 The `deploy_shinystan` function will deploy a ShinyStan app unique to your model
 to RStudio's ShinyApps service.
@@ -83,3 +85,34 @@ deploy_shinystan(my_sso, appName = "MyModel",
 If the deployment process is successful the url for your app will be printed to the console and it should open in your web browser. You can also view your app by going to http://www.shinyapps.io and logging into your account.
 
 
+## Deploying to a private server
+
+### Step 1: Private server with R, RStan and ShinyStan installed
+
+To deploy your app to a private server you need to have **R**, **rstan** and **shinystan** with all its dependencies installed on your private server. If you need help with that, there is a beautiful step by step guide which will help you with that: https://deanattali.com/2015/05/09/setup-rstudio-shiny-server-digital-ocean/.
+
+
+### Step 2: Use `deploy_shinystan` with `local = TRUE` argument to generate a complete Shiny code
+
+When local = TRUE, the `deploy_shinystan` function will create a folder containing all files needed for your server to run the ShinyStan application. 
+
+For the example below assume that 
+
+- `my_sso` is the shinystan object you want to use
+- the name you want to use for the app is `MyModel`.
+
+To render the app use the command
+
+```r
+deploy_shinystan(my_sso, appName = "MyModel", local = TRUE)
+```
+
+Then the directory called `MyModel` will be created in the working directory. You can open it and run or edit the generated Shiny code. To run it from your server, you need to copy the created folder to a directory on your server containing your other Shiny applications.
+
+You can also add a path argument which will generate the Shiny code on a specified absolute path, for example
+
+```r
+deploy_shinystan(my_sso, appName = "MyModel", local = TRUE, path = “C:/shiny-server”)
+```
+
+will generate the Shiny code at “C:/shiny-server” location.


### PR DESCRIPTION
Added argument to deploy_shinystan function which makes it generate shiny code, which can be uploaded to a private server and run there. Also updated the vignette for deployment, with description how to upload the shinystan application to a private server.

note1: It's my first pull request ever.
note2: I was having a trouble with  "ppcheck_yrep" argument when specified, the posterior predictive checks don't seem to work. However, this should be unrelated to my changes.