### PR TITLE
Fix #172: respect the `shiny.launch.browser`option

### DIFF
--- a/R/launch_shinystan.R
+++ b/R/launch_shinystan.R
@@ -151,7 +151,7 @@ launch_shinystan_demo <- function(demo_name = "eight_schools",
 # @param ... passed to shiny::runApp
 launch <- function(sso, rstudio = FALSE, ...) {
   launch.browser <- if (!rstudio) 
-    TRUE else getOption("shiny.launch.browser", interactive())
+    getOption("shiny.launch.browser", TRUE) else getOption("shiny.launch.browser", interactive())
   
   .sso_env$.SHINYSTAN_OBJECT <- sso  # see zzz.R for .sso_env
   on.exit(.sso_env$.SHINYSTAN_OBJECT <- NULL, add = TRUE)


### PR DESCRIPTION
See #172: If the user sets the `shiny.launch.browser` option to `FALSE` when running shinystan outside of RStudio, this change ensures that `launch_shinystan()` respects that. Otherwise, the default behavior (`launch.browser=TRUE`) is preserved.